### PR TITLE
refactor: 버스 버튼 hover 제거 및 direction 엔티티 null 허용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -363,12 +363,9 @@ function App() {
             const bus = buses[idx];
             if (bus && Number.isFinite(bus.lat) && Number.isFinite(bus.lng)) {
                 moveToLocation(bus.lat, bus.lng);
-                // Use the existing `Bubble` component to render the styled bubble
                 try {
-                    const dir = bus.direction;
-                    const label = dir === null || dir === undefined || String(dir).trim() === ""
-                        ? "셔틀버스"
-                        : `셔틀버스(${String(dir)} 방향)`;
+                    const dir = bus.direction?.trim() ?? "";
+                    const label = dir ? `셔틀버스(${dir} 방향)` : "셔틀버스";
                     setBubbleStop({ lat: bus.lat, lng: bus.lng, name: label });
                 } catch {
                     /* ignore */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -365,7 +365,10 @@ function App() {
                 moveToLocation(bus.lat, bus.lng);
                 // Use the existing `Bubble` component to render the styled bubble
                 try {
-                    const label = `셔틀버스(${String(bus.direction)} 방향)`;
+                    const dir = bus.direction;
+                    const label = dir === null || dir === undefined || String(dir).trim() === ""
+                        ? "셔틀버스"
+                        : `셔틀버스(${String(dir)} 방향)`;
                     setBubbleStop({ lat: bus.lat, lng: bus.lng, name: label });
                 } catch {
                     /* ignore */

--- a/src/components/BusStops.tsx
+++ b/src/components/BusStops.tsx
@@ -235,16 +235,6 @@ export default function BusStops({
                                 transition: "background-color 0.15s ease",
                                 opacity: disabled ? 0.6 : 1,
                             }}
-                            onPointerEnter={(e) => {
-                                if (disabled) return;
-                                e.currentTarget.style.backgroundColor =
-                                    "#0056b3";
-                            }}
-                            onPointerLeave={(e) => {
-                                if (disabled) return;
-                                e.currentTarget.style.backgroundColor =
-                                    "#007bff";
-                            }}
                         >
                             {n}
                         </button>

--- a/src/data/bus.ts
+++ b/src/data/bus.ts
@@ -3,7 +3,7 @@ export interface Bus {
     name: string;
     lat: number;
     lng: number;
-    direction: string;
+    direction: string|null;
 }
 
 export const buses: ReadonlyArray<Bus> = [
@@ -12,7 +12,7 @@ export const buses: ReadonlyArray<Bus> = [
         name: "bus1",
         lat: 37.323494,
         lng: 127.123008,
-        direction: "죽전역",
+        direction: null,
     },
     {
         id: 2,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 버그 수정
  * 방향 정보가 없을 때 말풍선 라벨에 null/undefined/빈 값이 노출되던 문제를 해결했습니다. 이제 방향이 없으면 “셔틀버스”, 있으면 “셔틀버스(… 방향)”으로 표시됩니다.
* 스타일
  * 숫자형 버스 버튼의 호버 배경색 변화를 제거하여 버튼 색상이 일정하게 유지됩니다. 전환 효과는 그대로 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->